### PR TITLE
Avoid array allocation in MemoryStreamExtensions.Append

### DIFF
--- a/BitTorrent/BEncoding.cs
+++ b/BitTorrent/BEncoding.cs
@@ -284,7 +284,7 @@ namespace BitTorrent
     {
         public static void Append(this MemoryStream stream, byte value)
         {
-            stream.Append(new[] { value });
+            stream.WriteByte(value);
         }
 
         public static void Append(this MemoryStream stream, byte[] values)


### PR DESCRIPTION
The temporary `byte[]` array allocation can be avoided by using `MemoryStream.WriteByte`.
