### PR TITLE
No longer throw FileNotFoundException

### DIFF
--- a/BitTorrent/BEncoding.cs
+++ b/BitTorrent/BEncoding.cs
@@ -28,9 +28,6 @@ namespace BitTorrent
 
         public static object DecodeFile(string path)
         {
-            if (!File.Exists(path))
-                throw new FileNotFoundException("unable to find file: " + path);
-
             byte[] bytes = File.ReadAllBytes(path);
 
             return BEncoding.Decode(bytes);


### PR DESCRIPTION
There's no need to check `File.Exists` and throw `FileNotFoundException`, as `File.ReadAllBytes` will throw if the file is not found.
